### PR TITLE
Added internationalization to login error message

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -39,7 +39,8 @@ export default {
   },
   login: {
     messages: {
-      sign_in:  'please sign in'
+      sign_in:  'please sign in',
+      error:    'Username or password is incorrect.'
     },
     labels: {
       password: 'Password',

--- a/app/locales/pt-BR/translations.js
+++ b/app/locales/pt-BR/translations.js
@@ -40,7 +40,8 @@ export default {
 
   login: {
     messages: {
-      sign_in:  'inscreva-se'
+      sign_in:  'inscreva-se',
+      error:    'Nome de usuário ou senha está incorreta.'
     },
     labels: {
       password: 'Senha',

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -9,7 +9,7 @@
 
           <h2 class="form-signin-heading">{{t 'login.messages.sign_in'}}</h2>
           {{#if errorMessage}}
-              <div class="alert alert-danger form-signin-alert" role="alert">{{errorMessage}}</div>
+              <div class="alert alert-danger form-signin-alert" role="alert">{{t 'login.messages.error'}}</div>
           {{/if}}
           <div class="form-group">
               {{input id='identification' value=identification placeholder=(t 'login.labels.username') class='form-control'}}


### PR DESCRIPTION
Instead of displaying the errorMessage that Pouch returns for an invalid
login attempt, display an error message form translations.js